### PR TITLE
Change default name of production image

### DIFF
--- a/.env
+++ b/.env
@@ -18,7 +18,7 @@ SELENIUM_IMAGE=selenium/standalone-firefox:2.53.1
 REDIS_IMAGE=redis
 
 # App image name for use if you intend to push it to docker registry/hub.
-APP_PROD_IMAGE=my-ez-app
+APP_PROD_IMAGE=my-ezplatform-ee-app
 APP_DOCKER_FILE=Dockerfile
 
 # Install config, used by .platform.app.yaml among others


### PR DESCRIPTION
### Problem

When I start creating production container, this will build image with my-ez-app.
For then platform-ee is the same configuration - then when i want to have 2 production build on same host, this create conflict for sharing same named container, with coped code.

### Solution

Change default name of container.

[Connected PR](https://github.com/timiTao/ezplatform/pull/1) in ezplatform